### PR TITLE
CORE-4061 Add test stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,9 +71,15 @@ pipeline {
             steps {
                 sh '''
                     helm install prereqs corda-prereqs-$CHART_VERSION.tgz -n $NAMESPACE --create-namespace --wait
-                    helm test prereqs
-                    kubectl delete namespace $NAMESPACE
+                    helm test prereqs -n $NAMESPACE
                 '''
+            }
+            post {
+                always {
+                    sh '''
+                        kubectl delete namespace $NAMESPACE
+                    '''
+                }
             }
         }
         stage('Publish') {


### PR DESCRIPTION
Deploys the packaged Helm chart to the `eks-e2e` cluster and then runs `helm test` against it before cleaning up the namespace.