### PR TITLE
CORE-6037/Changed number of maximum postgres connections

### DIFF
--- a/charts/corda-dev/values.yaml
+++ b/charts/corda-dev/values.yaml
@@ -62,4 +62,5 @@ postgresql:
           echo "localhost:${POSTGRES_PORT_NUMBER:-5432}:$POSTGRESQL_DATABASE:postgres:$POSTGRES_POSTGRES_PASSWORD" > $PGPASSFILE
           psql -v ON_ERROR_STOP=1 cordacluster <<-EOF
             ALTER ROLE "$POSTGRES_USER" NOSUPERUSER CREATEDB CREATEROLE INHERIT LOGIN;
+            ALTER system SET max_connections = 1000;
           EOF


### PR DESCRIPTION
Changed maximum postgres connections from default 100 to 1000 to accommodate multiple corda clusters using the same prereqs.